### PR TITLE
fix: move schema-dts from devDependencies to dependencies - Fixes #36…

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
 		"release": "pnpm run build:packages && changeset publish"
 	},
 	"devDependencies": {
-		"@changesets/cli": "^2.27.12"
+		"@changesets/cli": "^2.29.4",
+		"prettier": "^3.4.2",
+		"prettier-plugin-svelte": "^3.3.3"
 	}
 }

--- a/packages/svead/package.json
+++ b/packages/svead/package.json
@@ -52,6 +52,9 @@
 	"peerDependencies": {
 		"svelte": "^4.0.0 || ^5.0.0"
 	},
+	"dependencies": {
+		"schema-dts": "^1.1.2"
+	},
 	"devDependencies": {
 		"@playwright/test": "^1.50.1",
 		"@sveltejs/adapter-auto": "^4.0.0",
@@ -70,7 +73,6 @@
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.3",
 		"publint": "^0.3.2",
-		"schema-dts": "^1.1.2",
 		"svelte": "5.26.2",
 		"svelte-check": "^4.1.4",
 		"tslib": "^2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,14 @@ importers:
   .:
     devDependencies:
       '@changesets/cli':
-        specifier: ^2.27.12
+        specifier: ^2.29.4
         version: 2.29.4
+      prettier:
+        specifier: ^3.4.2
+        version: 3.4.2
+      prettier-plugin-svelte:
+        specifier: ^3.3.3
+        version: 3.3.3(prettier@3.4.2)(svelte@5.26.2)
 
   apps/web:
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,10 @@ importers:
         version: 3.0.5(jiti@1.21.6)(jsdom@26.0.0)(yaml@2.6.0)
 
   packages/svead:
+    dependencies:
+      schema-dts:
+        specifier: ^1.1.2
+        version: 1.1.2(typescript@5.7.3)
     devDependencies:
       '@playwright/test':
         specifier: ^1.50.1
@@ -167,9 +171,6 @@ importers:
       publint:
         specifier: ^0.3.2
         version: 0.3.2
-      schema-dts:
-        specifier: ^1.1.2
-        version: 1.1.2(typescript@5.7.3)
       svelte:
         specifier: 5.26.2
         version: 5.26.2


### PR DESCRIPTION
…2 - Users were not getting TypeScript type hints for SchemaOrgProps['schema'] because schema-dts was only in devDependencies. Moving it to dependencies ensures proper type support for end users.